### PR TITLE
Investigate `qualified_min` testcase

### DIFF
--- a/testcases/qualified_min/data.ttl
+++ b/testcases/qualified_min/data.ttl
@@ -9,3 +9,17 @@
 :instance1 a :qualified_min_shape ;
     :path1 "value1" ;
 .
+
+:instance2 a :qualified_min_shape ;
+    :path1 "value2" ;
+.
+
+:instance3 a :qualified_min_shape .
+
+:instance4 a :qualified_min_shape ;
+    :path1 "value1", "value2" ;
+.
+
+:instance5 a :qualified_min_shape ;
+    :path1 "bad value" ;
+.

--- a/testcases/qualified_min/pyshacl/report.ttl
+++ b/testcases/qualified_min/pyshacl/report.ttl
@@ -1,6 +1,25 @@
+@prefix : <urn:qualified_min_shape/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 [] a sh:ValidationReport ;
-    sh:conforms true .
+    sh:conforms false ;
+    sh:result [ a sh:ValidationResult ;
+            sh:focusNode :instance4 ;
+            sh:resultMessage "More than 1 values on :instance4->:path1" ;
+            sh:resultPath :path1 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+            sh:sourceShape _:n70e78fab2d2c4c24983b5d9f3fb63913b1 ],
+        [ a sh:ValidationResult ;
+            sh:focusNode :instance3 ;
+            sh:resultMessage "Less than 1 values on :instance3->:path1" ;
+            sh:resultPath :path1 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+            sh:sourceShape _:n70e78fab2d2c4c24983b5d9f3fb63913b1 ] .
+
+_:n70e78fab2d2c4c24983b5d9f3fb63913b1 sh:maxCount 1 ;
+    sh:minCount 1 ;
+    sh:path :path1 .
 

--- a/testcases/qualified_min/pyshacl/report.txt
+++ b/testcases/qualified_min/pyshacl/report.txt
@@ -1,2 +1,15 @@
 Validation Report
-Conforms: True
+Conforms: False
+Results (2):
+Constraint Violation in MaxCountConstraintComponent (http://www.w3.org/ns/shacl#MaxCountConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: [ sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path :path1 ]
+	Focus Node: :instance4
+	Result Path: :path1
+	Message: More than 1 values on :instance4->:path1
+Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: [ sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:path :path1 ]
+	Focus Node: :instance3
+	Result Path: :path1
+	Message: Less than 1 values on :instance3->:path1

--- a/testcases/qualified_min/shapes.ttl
+++ b/testcases/qualified_min/shapes.ttl
@@ -1,4 +1,5 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -9,20 +10,20 @@
 :qualified_min_shape a sh:NodeShape, owl:Class ;
     sh:property [
         sh:path :path1 ;
-        sh:qualifiedValueShapeDisjoint true ;
         sh:minCount 1 ;
-        sh:qualifiedMinCount 1 ;
-        sh:qualifiedValueShape [
-            sh:hasValue "value1" ;
-      ] ;
-    sh:property [
-        sh:path :path1 ;
-        sh:qualifiedMinCount 1 ;
-        # sh:minCount 1 ;
-        sh:qualifiedValueShapeDisjoint true ;
-        sh:qualifiedValueShape [
-            sh:hasValue "value2" ;
-          ] ;
-      ] ;
-    ];
-  .
+        sh:maxCount 1 ;
+    ] ;
+	sh:property [
+		sh:path :path1 ;
+		sh:qualifiedValueShape [ sh:hasValue "value1" ] ;
+		sh:qualifiedValueShapesDisjoint true ;
+		sh:qualifiedMinCount 0 ;
+		sh:qualifiedMaxCount 1 ;
+	] ;
+	sh:property [
+		sh:path :path1 ;
+		sh:qualifiedValueShape [ sh:hasValue "value2" ] ;
+		sh:qualifiedValueShapesDisjoint true ;
+		sh:qualifiedMinCount 0 ;
+		sh:qualifiedMaxCount 1 ;
+	] .


### PR DESCRIPTION
@lazlop  there was a typo in your original `shape.ttl` file in the qualified_min case where one of the property shapes was nested within the other, which gave weird results. I've fixed up the test case here by changing the modeling approach slightly to be more explicit. This might go under its *own* test case rather than replacing yours because I want to test the "shorthand" that is in your original test case

Curiously, the TopQuadrant SHACL program is not failing on this! I'm going to dig into this, but it might be worth trying it out on your own installation (do you have Composer?)